### PR TITLE
Small editorial fixes. 

### DIFF
--- a/draft-pala-klaussner-composite-kofn.html
+++ b/draft-pala-klaussner-composite-kofn.html
@@ -20,8 +20,8 @@ keys and signatures that can be individually trusted to implement a generic
 1-threshold and K-threshold signature validation procedures. 
        This document relies on the definition of CompositePublicKey, CompositePrivateKey,
 and CompositeSignature which are sequences of the respective structure for each
-component algorithm as defined in I-D.ounsworth-pq-composite-keys and
-I-D.ounsworth-pq-composite-sigs respectively. 
+component algorithm as defined in   and
+  respectively. 
        
 
 
@@ -1254,8 +1254,8 @@ keys and signatures that can be individually trusted to implement a generic
 1-threshold and K-threshold signature validation procedures.<a href="#section-abstract-2" class="pilcrow">¶</a></p>
 <p id="section-abstract-3">This document relies on the definition of CompositePublicKey, CompositePrivateKey,
 and CompositeSignature which are sequences of the respective structure for each
-component algorithm as defined in I-D.ounsworth-pq-composite-keys and
-I-D.ounsworth-pq-composite-sigs respectively.<a href="#section-abstract-3" class="pilcrow">¶</a></p>
+component algorithm as defined in <span>[<a href="#I-D.ounsworth-pq-composite-keys" class="xref">I-D.ounsworth-pq-composite-keys</a>]</span> and
+<span>[<a href="#I-D.ounsworth-pq-composite-sigs" class="xref">I-D.ounsworth-pq-composite-sigs</a>]</span> respectively.<a href="#section-abstract-3" class="pilcrow">¶</a></p>
 </section>
 <div id="status-of-memo">
 <section id="section-boilerplate.1">
@@ -1312,7 +1312,7 @@ I-D.ounsworth-pq-composite-sigs respectively.<a href="#section-abstract-3" class
             <p id="section-toc.1-1.2.1" class="keepWithNext"><a href="#section-2" class="xref">2</a>.  <a href="#name-introduction-2" class="xref">Introduction</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.3">
-            <p id="section-toc.1-1.3.1" class="keepWithNext"><a href="#section-3" class="xref">3</a>.  <a href="#name-composite-crypto-keys-2" class="xref">Composite Crypto Keys</a></p>
+            <p id="section-toc.1-1.3.1" class="keepWithNext"><a href="#section-3" class="xref">3</a>.  <a href="#name-composite-crypto-signature-p" class="xref">Composite Crypto Signature Plus</a></p>
 </li>
           <li class="compact toc ulBare ulEmpty" id="section-toc.1-1.4">
             <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-the-composite-crypto-plus-mo" class="xref">The Composite Crypto Plus model</a></p>
@@ -1425,8 +1425,8 @@ within PKIX or CMS structures.<a href="#section-2-5" class="pilcrow">¶</a></p>
 </div>
 <div id="composite-data-structures">
 <section id="section-3">
-      <h2 id="name-composite-crypto-keys-2">
-<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-composite-crypto-keys-2" class="section-name selfRef">Composite Crypto Keys</a>
+      <h2 id="name-composite-crypto-signature-p">
+<a href="#section-3" class="section-number selfRef">3. </a><a href="#name-composite-crypto-signature-p" class="section-name selfRef">Composite Crypto Signature Plus</a>
       </h2>
 <p id="section-3-1">In this document import the definition of Composite Keys as defined in <span>[<a href="#I-D.ounsworth-pq-composite-keys" class="xref">I-D.ounsworth-pq-composite-keys</a>]</span>.<a href="#section-3-1" class="pilcrow">¶</a></p>
 <p id="section-3-2">In this document we also import the definition of Composite Signatures as defined in
@@ -1484,7 +1484,7 @@ are required to consider the signature valid.<a href="#section-4.1-3" class="pil
 <a href="#section-4.2" class="section-number selfRef">4.2. </a><a href="#name-signature-generation-2" class="section-name selfRef">Signature Generation</a>
         </h3>
 <p id="section-4.2-1">When generating CompositePlus signatures, the signer follows the same procedures as
-described in I-D.draft-ounsworth-pq-composite-sigs-05.<a href="#section-4.2-1" class="pilcrow">¶</a></p>
+described in <span>[<a href="#I-D.ounsworth-pq-composite-sigs" class="xref">I-D.ounsworth-pq-composite-sigs</a>]</span>.<a href="#section-4.2-1" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="signature-validation">
@@ -1493,7 +1493,7 @@ described in I-D.draft-ounsworth-pq-composite-sigs-05.<a href="#section-4.2-1" c
 <a href="#section-4.3" class="section-number selfRef">4.3. </a><a href="#name-signature-validation-2" class="section-name selfRef">Signature Validation</a>
         </h3>
 <p id="section-4.3-1">When validating CompositePlus signatures, the verifier follows the same procedures
-as described in Section 5.2 of I-D.draft-ounsworth-pq-composite-sigs-05 with the
+as described in Section 5.2 of <span>[<a href="#I-D.ounsworth-pq-composite-sigs" class="xref">I-D.ounsworth-pq-composite-sigs</a>]</span> with the
 following modifications.<a href="#section-4.3-1" class="pilcrow">¶</a></p>
 <p id="section-4.3-2">If the optional requiredValidSignatures field is present in the signature, the
 verifier can modify the validation process as follows:<a href="#section-4.3-2" class="pilcrow">¶</a></p>

--- a/draft-pala-klaussner-composite-kofn.mkd
+++ b/draft-pala-klaussner-composite-kofn.mkd
@@ -73,8 +73,8 @@ keys and signatures that can be individually trusted to implement a generic
 
 This document relies on the definition of CompositePublicKey, CompositePrivateKey,
 and CompositeSignature which are sequences of the respective structure for each
-component algorithm as defined in I-D.ounsworth-pq-composite-keys and
-I-D.ounsworth-pq-composite-sigs respectively.
+component algorithm as defined in {{I-D.ounsworth-pq-composite-keys}} and
+{{I-D.ounsworth-pq-composite-sigs}} respectively.
 
 <!-- End of Abstract -->
 
@@ -143,7 +143,7 @@ within PKIX or CMS structures.
 
 <!-- End of Introduction section -->
 
-# Composite Crypto Keys {#composite-data-structures}
+# Composite Crypto Signature Plus {#composite-data-structures}
 
 In this document import the definition of Composite Keys as defined in {{I-D.ounsworth-pq-composite-keys}}.
 
@@ -198,12 +198,12 @@ are required to consider the signature valid.
 ## Signature Generation
 
 When generating CompositePlus signatures, the signer follows the same procedures as
-described in I-D.draft-ounsworth-pq-composite-sigs-05.
+described in {{I-D.ounsworth-pq-composite-sigs}}.
 
 ## Signature Validation
 
 When validating CompositePlus signatures, the verifier follows the same procedures
-as described in Section 5.2 of I-D.draft-ounsworth-pq-composite-sigs-05 with the
+as described in Section 5.2 of {{I-D.ounsworth-pq-composite-sigs}} with the
 following modifications.
 
 If the optional requiredValidSignatures field is present in the signature, the

--- a/draft-pala-klaussner-composite-kofn.txt
+++ b/draft-pala-klaussner-composite-kofn.txt
@@ -31,8 +31,8 @@ Abstract
    This document relies on the definition of CompositePublicKey,
    CompositePrivateKey, and CompositeSignature which are sequences of
    the respective structure for each component algorithm as defined in
-   I-D.ounsworth-pq-composite-keys and I-D.ounsworth-pq-composite-sigs
-   respectively.
+   [I-D.ounsworth-pq-composite-keys] and
+   [I-D.ounsworth-pq-composite-sigs] respectively.
 
 Status of This Memo
 
@@ -76,7 +76,7 @@ Table of Contents
 
    1.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   2
    2.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
-   3.  Composite Crypto Keys . . . . . . . . . . . . . . . . . . . .   3
+   3.  Composite Crypto Signature Plus . . . . . . . . . . . . . . .   3
    4.  The Composite Crypto Plus model . . . . . . . . . . . . . . .   4
      4.1.  1-threshold (1 of N) and K-threshold (K of N)
            signatures  . . . . . . . . . . . . . . . . . . . . . . .   4
@@ -156,7 +156,7 @@ Internet-Draft              K-threshold Sigs                October 2022
    This document is intended for general applicability anywhere that
    keys are used within PKIX or CMS structures.
 
-3.  Composite Crypto Keys
+3.  Composite Crypto Signature Plus
 
    In this document import the definition of Composite Keys as defined
    in [I-D.ounsworth-pq-composite-keys].
@@ -234,13 +234,13 @@ Internet-Draft              K-threshold Sigs                October 2022
 4.2.  Signature Generation
 
    When generating CompositePlus signatures, the signer follows the same
-   procedures as described in I-D.draft-ounsworth-pq-composite-sigs-05.
+   procedures as described in [I-D.ounsworth-pq-composite-sigs].
 
 4.3.  Signature Validation
 
    When validating CompositePlus signatures, the verifier follows the
-   same procedures as described in Section 5.2 of I-D.draft-ounsworth-
-   pq-composite-sigs-05 with the following modifications.
+   same procedures as described in Section 5.2 of
+   [I-D.ounsworth-pq-composite-sigs] with the following modifications.
 
    If the optional requiredValidSignatures field is present in the
    signature, the verifier can modify the validation process as follows:


### PR DESCRIPTION
Renamed section header from 'Keys' to 'Signatures'.

Removed repeated paragraph when describing the CompositeSignaturePlusValue.