### PR TITLE
Integrates and Expands the Fix for the validation algorithm.

### DIFF
--- a/draft-pala-klaussner-composite-kofn.mkd
+++ b/draft-pala-klaussner-composite-kofn.mkd
@@ -289,15 +289,22 @@ validation procedures are modified in two different ways:
 - Allowing to skip some component signature validation as needed
 
 The total number of failed and skipped component signature validation
-cannot exceed the `K` value encoded in the MultiKey-params integer value.
-When this happens, the composite signature MUST be considered
-invalid.
+cannot exceed the total number of signatures (`n`) minus the number of
+required validation (`K`):
+~~~
+F <= n - K
+~~~
+{: artwork-align="center" artwork-name="failures-boundary" }
+
+where `F` represents the maximum number of allowed component signatures'
+failures based on the `K` value encoded in the MultiKey-params integer value.
+When this value `F` exceeds `n - K`, the composite signature MUST be
+considered invalid.
 
 When compared to the composite signatures' validation process, the only
 modified step is during the individual component's validation for...loop
 where the invalid signature output is emitted only if the number of
-failures (variable `F`) exceeds the value encoded in the public key
-parameter (variable `K`).
+failures (variable `F`) exceeds the maximum.
 
 The Input and Output definitions are the same as defined in composite:
 
@@ -337,13 +344,15 @@ with a MultiKey key:
    exceed the parameter K, then the entire signature validation
    fails.
 
-   K := MultiKey-params | 0
+   K := MultiKey-params(1..max) | n
    F := 0 
    for i := 1 to n:
-     if not verify( Pi, M, Si, Ai ) and F > K:
+     if not verify( Pi, M, Si, Ai ) and F > n - K:
        output "Invalid signature"
      else:
        F++
+     if (i - F >= K):
+       break;
 
 3. Output "Valid signature"
 ~~~


### PR DESCRIPTION
This fix integrate's Jan's fix for the validation algorithm and expands on top of it to provide early validation aborts if there are not enough individual components' validations to be performed. This change also provides additional descriptive text related to the protocol.